### PR TITLE
Distinguish Ruby version from the Host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -168,6 +168,7 @@ COPY Gemfile /Gemfile
 ENV GEM_PATH /usr/local/bundle
 ENV GEM_HOME /usr/local/bundle
 RUN mkdir -p /usr/local/bundle
+ENV PATH $GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH
 
 RUN echo "fastlane" && \
     cd / && \


### PR DESCRIPTION
ref: https://bundler.io/guides/bundler_docker_guide.html#dockerfiles-for-multiple-ruby-applications-and-gems

## Consequences

> Why both `GEM_PATH` & `GEM_HOME`?

As stated from the above article also mentioned in [here](https://stackoverflow.com/a/11277228/3763032), that we need to respect both env to make sure the desired directory / path is used when running this Docker

The changes included in 2328f6a7ebd28a097226bfbf0e547e856bf0812a was inspired by this [Dockerfile here](https://github.com/heroku/docker-ruby/blob/master/Dockerfile#L7)

> It seems missing to assign `BUNDLE_PATH`?

Agreed. Will release this snapshot of Docker image first to test, if `GEM_*` is enough to satisfy the bundler. If not, might need to add `ENV BUNDLE_PATH <desired bundle location>` later on

ref: https://stackoverflow.com/a/42677414/3763032